### PR TITLE
Allow URL param in path which ends with a colon param

### DIFF
--- a/lib/api_client_builder/url_generator.rb
+++ b/lib/api_client_builder/url_generator.rb
@@ -21,7 +21,7 @@ module APIClientBuilder
     #
     # @return [URI] the fully built route
     def build_route(route, **params)
-      string_params = route.split(%r{[\/=&]}).select { |param| param.start_with?(':') }
+      string_params = route.split(%r{[\/?=&]}).select { |param| param.start_with?(':') }
       symboled_params = string_params.map { |param| param.tr(':', '').to_sym }
 
       new_route = route.clone

--- a/spec/lib/api_client_builder/url_generator_spec.rb
+++ b/spec/lib/api_client_builder/url_generator_spec.rb
@@ -59,6 +59,19 @@ module APIClientBuilder
           end
         end
 
+        context "the route has URL param just after a colon params path" do
+          let(:url) { 'objects/:object_id?foo=bar' }
+          let(:url_generator) { URLGenerator.new('https://www.domain.com/api/endpoints/') }
+
+          subject do
+            route = url_generator.build_route(url, object_id: 1)
+          end
+
+          it do
+            is_expected.to eq URI.parse('https://www.domain.com/api/endpoints/objects/1?foo=bar')
+          end
+        end
+
       end
 
       context 'route with colon params and non matching keys' do


### PR DESCRIPTION
Currently, route like `objects/:object_id?foo=bar` cannot properly parsed, and an error is raised.

This patch add question mark `?` to separators to solve this issue.