### PR TITLE
Upgrade from Rubocop 0.57 to 1.88

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ Metrics/BlockLength:
   Exclude:
     - spec/**/*.rb
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 120 # Default: 80
 
 Metrics/MethodLength:
@@ -19,16 +19,4 @@ Style/Documentation:
   # Classes with no body and namespace modules are exempt from the check.
   # Namespace modules are modules that have nothing in their bodies except
   # classes or other modules.
-  Enabled: false
-
-Style/FrozenStringLiteralComment:
-  # `when_needed` will add the frozen string literal comment to files
-  # only when the `TargetRubyVersion` is set to 2.3+.
-  # `always` will always add the frozen string literal comment to a file
-  # regardless of the Ruby version or if `freeze` or `<<` are called on a
-  # string literal. If you run code against multiple versions of Ruby, it is
-  # possible that this will create errors in Ruby 2.3.0+.
-  #
-  # See: https://wyeworks.com/blog/2015/12/1/immutable-strings-in-ruby-2-dot-3
-  EnforcedStyle: when_needed
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Declare your gem's dependencies in logging.gemspec.

--- a/api_client_builder.gemspec
+++ b/api_client_builder.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path('lib/api_client_builder/version', __dir__)
 
 Gem::Specification.new do |gem|
@@ -13,9 +15,8 @@ Gem::Specification.new do |gem|
 
   gem.license = 'MIT'
 
-  gem.add_development_dependency 'pry'
   gem.add_development_dependency 'rspec', '~> 3.7'
-  gem.add_development_dependency 'rubocop', '~> 0.57.2'
+  gem.add_development_dependency 'rubocop', '~> 1.88'
   gem.add_development_dependency 'simplecov', '~> 0'
 
   gem.files         = `git ls-files`.split("\n")

--- a/lib/api_client_builder.rb
+++ b/lib/api_client_builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'uri'
 
 require_relative 'api_client_builder/version'

--- a/lib/api_client_builder/api_client.rb
+++ b/lib/api_client_builder/api_client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module APIClientBuilder
   # The base APIClient that defines the interface for defining an API Client.
   # Should be sub-classed and then provided an HTTPClient handler and a

--- a/lib/api_client_builder/delete_request.rb
+++ b/lib/api_client_builder/delete_request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module APIClientBuilder
   class DeleteRequest < Request
     # Yields the response body if the response was successful. Will call

--- a/lib/api_client_builder/get_collection_request.rb
+++ b/lib/api_client_builder/get_collection_request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module APIClientBuilder
   # The multi item response object to be used as the container for
   # collection responses from the defined API
@@ -9,29 +11,21 @@ module APIClientBuilder
     # strategy is defined concretely on the response handler.
     #
     # @return [JSON] the http response body
-    # rubocop:disable Metrics/AbcSize
-    def each
-      if block_given?
-        each_page do |page|
-          if page.success?
-            page.body.each do |item|
-              yield(item)
-            end
-          elsif response_handler.respond_to?(:retryable?) && response_handler.retryable?(page.status_code)
-            retried_page = attempt_retry
+    def each(&block)
+      return Enumerator.new(self, :each) unless block_given?
 
-            retried_page.body.each do |item|
-              yield(item)
-            end
-          else
-            notify_error_handlers(page)
-          end
+      each_page do |page|
+        if page.success?
+          page.body.each(&block)
+        elsif response_handler.respond_to?(:retryable?) && response_handler.retryable?(page.status_code)
+          retried_page = attempt_retry
+
+          retried_page.body.each(&block)
+        else
+          notify_error_handlers(page)
         end
-      else
-        Enumerator.new(self, :each)
       end
     end
-    # rubocop:enable Metrics/AbcSize
 
     private
 

--- a/lib/api_client_builder/get_item_request.rb
+++ b/lib/api_client_builder/get_item_request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module APIClientBuilder
   # The single item response object to be used as the container for
   # singular responses from the defined API

--- a/lib/api_client_builder/post_request.rb
+++ b/lib/api_client_builder/post_request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module APIClientBuilder
   class PostRequest < Request
     # Yields the response body if the response was successful. Will call

--- a/lib/api_client_builder/put_request.rb
+++ b/lib/api_client_builder/put_request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module APIClientBuilder
   class PutRequest < Request
     # Yields the response body if the response was successful. Will call

--- a/lib/api_client_builder/request.rb
+++ b/lib/api_client_builder/request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module APIClientBuilder
   class DefaultPageError < StandardError; end
 
@@ -49,7 +51,7 @@ module APIClientBuilder
 
       if page.success?
         response_handler.reset_retries
-        return page
+        page
       elsif response_handler.retryable?(page.status_code)
         attempt_retry
       else

--- a/lib/api_client_builder/response.rb
+++ b/lib/api_client_builder/response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module APIClientBuilder
   # The default page object to be used to hold the response from the API
   # in your response handler object. Any response object that will replace this

--- a/lib/api_client_builder/url_generator.rb
+++ b/lib/api_client_builder/url_generator.rb
@@ -1,12 +1,15 @@
+# frozen_string_literal: true
+
 module APIClientBuilder
   class NoURLError < StandardError; end
+
   class URLGenerator
     # Receives a domain and parses it into a URI
     #
     # @param domain [String] the domain of the API
     def initialize(domain)
       @base_uri = URI.parse(domain)
-      @base_uri = URI.parse('https://' + domain) if @base_uri.scheme.nil?
+      @base_uri = URI.parse("https://#{domain}") if @base_uri.scheme.nil?
       @base_uri.path << '/' unless @base_uri.path.end_with?('/')
     end
 
@@ -21,14 +24,15 @@ module APIClientBuilder
     #
     # @return [URI] the fully built route
     def build_route(route, **params)
-      string_params = route.split(%r{[\/=&]}).select { |param| param.start_with?(':') }
+      string_params = route.split(%r{[/=&]}).select { |param| param.start_with?(':') }
       symboled_params = string_params.map { |param| param.tr(':', '').to_sym }
 
       new_route = route.clone
       symboled_params.each do |param|
         value = params[param]
         raise ArgumentError, "Param :#{param} is required" unless value
-        new_route.gsub!(":#{param}", encode_ascii(value.to_s))
+
+        new_route = new_route.gsub(":#{param}", encode_ascii(value.to_s))
       end
 
       @base_uri.merge(new_route)
@@ -39,6 +43,7 @@ module APIClientBuilder
     def encode_ascii(str)
       str.each_char.map do |c|
         next c if c.force_encoding('ascii').valid_encoding?
+
         CGI.escape c
       end.join
     end

--- a/lib/api_client_builder/version.rb
+++ b/lib/api_client_builder/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module APIClientBuilder
-  VERSION = '2.0.0'.freeze
+  VERSION = '2.0.0'
 end

--- a/spec/lib/api_client_builder/api_client_spec.rb
+++ b/spec/lib/api_client_builder/api_client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require_relative 'test_client/client'
 

--- a/spec/lib/api_client_builder/delete_request_spec.rb
+++ b/spec/lib/api_client_builder/delete_request_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require_relative 'test_client/client'
 

--- a/spec/lib/api_client_builder/get_collection_request_spec.rb
+++ b/spec/lib/api_client_builder/get_collection_request_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require_relative 'test_client/client'
 

--- a/spec/lib/api_client_builder/get_item_request_spec.rb
+++ b/spec/lib/api_client_builder/get_item_request_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require_relative 'test_client/client'
 

--- a/spec/lib/api_client_builder/post_request_spec.rb
+++ b/spec/lib/api_client_builder/post_request_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require_relative 'test_client/client'
 

--- a/spec/lib/api_client_builder/put_request_spec.rb
+++ b/spec/lib/api_client_builder/put_request_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require_relative 'test_client/client'
 

--- a/spec/lib/api_client_builder/request_spec.rb
+++ b/spec/lib/api_client_builder/request_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require_relative 'test_client/client'
 

--- a/spec/lib/api_client_builder/response_spec.rb
+++ b/spec/lib/api_client_builder/response_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 module APIClientBuilder

--- a/spec/lib/api_client_builder/test_client/client.rb
+++ b/spec/lib/api_client_builder/test_client/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'response_handler'
 require_relative 'http_client_handler'
 

--- a/spec/lib/api_client_builder/test_client/http_client_handler.rb
+++ b/spec/lib/api_client_builder/test_client/http_client_handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module TestClient
   class HTTPClientHandler
     def initialize(domain)

--- a/spec/lib/api_client_builder/test_client/response_handler.rb
+++ b/spec/lib/api_client_builder/test_client/response_handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module TestClient
   class ResponseHandler
     SUCCESS_STATUS = 200

--- a/spec/lib/api_client_builder/url_generator_spec.rb
+++ b/spec/lib/api_client_builder/url_generator_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 module APIClientBuilder
@@ -39,26 +41,27 @@ module APIClientBuilder
                                         '?sample[]=%E1%BD%A48%E1%BD%A49%E1%BD%A4A&success=party%E1%BD%A4C'))
         end
 
-        context "and the route has multiple colon params in they query string" do
-          let(:url) { 'object_one/:object_one_id/:object_one_id/object&as_user_id=:user_object_id&param_2=:param_2&per_page=100' }
+        context 'and the route has multiple colon params in they query string' do
+          let(:url) do
+            'object_one/:object_one_id/:object_one_id/object&as_user_id=:user_object_id&param2=:param2&per_page=100'
+          end
           let(:url_generator) { URLGenerator.new('https://www.domain.com/api/endpoints/') }
 
           subject do
-            route = url_generator.build_route(
+            url_generator.build_route(
               url,
               object_one_id: '4',
               user_object_id: '1',
-              param_2: 'anotherqueryparam'
+              param2: 'anotherqueryparam'
             )
           end
 
           it do
             is_expected.to eq URI.parse(
-              'https://www.domain.com/api/endpoints/object_one/4/4/object&as_user_id=1&param_2=anotherqueryparam&per_page=100'
+              'https://www.domain.com/api/endpoints/object_one/4/4/object&as_user_id=1&param2=anotherqueryparam&per_page=100'
             )
           end
         end
-
       end
 
       context 'route with colon params and non matching keys' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'simplecov'
 SimpleCov.start do
   add_filter 'lib/api_client_builder/version.rb'


### PR DESCRIPTION
Most of these changes are just from Rubocop's autocorrect feature. But I made a few simple, manual fixes too. Like to
`APIClientBuilder::GetCollecitonRequest#each` complexity and spec example symbol naming.